### PR TITLE
Cleanup type inference errors

### DIFF
--- a/src/Cache.jl
+++ b/src/Cache.jl
@@ -90,7 +90,7 @@ can be repeated in the sample.
 """
 CacheRandomSample(p::AbstractProblem, n::Int) = CacheRandomSample(p.cache, n)
 (CacheRandomSample(c::PointCache{T}, n::Int)::Vector{Vector{T}}) where T =
-    length(c.order) == 0 ? [] : rand(c.order, n)
+    length(c.order) == 0 ? Vector{T}[] : rand(c.order, n)
 
 """
     CacheInitialPoint(p::AbstractProblem)

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -26,7 +26,7 @@ parameterisation can be ignored.
 mutable struct DSProblem{T} <: AbstractProblem{T}
     #= Problem Definition =#
     objective::Function
-    constraints::Constraints
+    constraints::Constraints{T}
     #Problem size
     N::Int
     user_initial_point::Union{Vector{T},Nothing}
@@ -298,20 +298,20 @@ function Finish(p)
 end
 
 """
-    EvaluatePoint!(p::DSProblem{T}, trial_points)::IterationOutcome where T
+    EvaluatePoint!(p::DSProblem{FT}, trial_points)::IterationOutcome where {FT<:AbstractFloat}
 
 Determine whether the set of trial points result in a dominating, improving, or unsuccesful
 algorithm iteration. Update the feasible and infeasible incumbent points of `p`.
 """
-function EvaluatePoint!(p::DSProblem{T}, trial_points::Vector{Vector{T}})::IterationOutcome where {T<:AbstractFloat}
+function EvaluatePoint!(p::DSProblem{FT}, trial_points::Vector{Vector{FT}})::IterationOutcome where {FT<:AbstractFloat}
     #TODO could split into an evaluation function and an update function
     isempty(trial_points) && return Unsuccessful
 
     #Variables to store the best evaluated points
-    feasible_point = isnothing(p.x) ? Inf * ones(p.N) : p.x
-    feasible_cost = isnothing(p.x_cost) ? Inf : p.x_cost
-    infeasible_point = isnothing(p.i) ? Inf * ones(p.N) : p.i
-    infeasible_cost = isnothing(p.i_cost) ? Inf : p.i_cost
+    feasible_point = isnothing(p.x) ? inf(FT) * ones(p.N) : p.x
+    feasible_cost = isnothing(p.x_cost) ? inf(FT) : p.x_cost
+    infeasible_point = isnothing(p.i) ? inf(FT) * ones(p.N) : p.i
+    infeasible_cost = isnothing(p.i_cost) ? inf(FT) : p.i_cost
 
     #The current minimum hmax value for all collections
     h_min = GetOldHmaxSum(p.constraints)
@@ -354,8 +354,8 @@ function EvaluatePoint!(p::DSProblem{T}, trial_points::Vector{Vector{T}})::Itera
 
     result = Unsuccessful
 
-    incum_i_cost = isnothing(p.i_cost) ? Inf : p.i_cost
-    incum_x_cost = isnothing(p.x_cost) ? Inf : p.x_cost
+    incum_i_cost = isnothing(p.i_cost) ? inf(FT) : p.i_cost
+    incum_x_cost = isnothing(p.x_cost) ? inf(FT) : p.x_cost
 
 
     # Dominates if there is a feasible improvement, or an infeasible point with

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -56,7 +56,7 @@ mutable struct DSProblem{T} <: AbstractProblem{T}
     status::Status
 
     #= Solver Config =#
-    config::Config
+    config::Config{T}
 
     DSProblem(N::Int;kwargs...) = DSProblem{Float64}(N; kwargs...)
 

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -23,7 +23,7 @@ choices are (LTMADS)[@ref] and (NullSearch)[@ref] respectively.
 Note that if working with `Float64` (normally the case) then the type
 parameterisation can be ignored.
 """
-mutable struct DSProblem{T, MT, ST} <: AbstractProblem{T} where {MT <: AbstractMesh, ST <: AbstractSearch}
+mutable struct DSProblem{T, MT, ST, PT} <: AbstractProblem{T} where {MT <: AbstractMesh, ST <: AbstractSearch, PT <: AbstractPoll}
     #= Problem Definition =#
     objective::Function
     constraints::Constraints{T}
@@ -56,7 +56,7 @@ mutable struct DSProblem{T, MT, ST} <: AbstractProblem{T} where {MT <: AbstractM
     status::Status
 
     #= Solver Config =#
-    config::Config{T, MT, ST}
+    config::Config{T, MT, ST, PT}
 
     DSProblem(N::Int;kwargs...) = DSProblem{Float64}(N; kwargs...)
 
@@ -70,7 +70,7 @@ mutable struct DSProblem{T, MT, ST} <: AbstractProblem{T} where {MT <: AbstractM
                           kwargs...
                          ) where T
 
-        p = new{T, Mesh{T}, typeof(search)}()
+        p = new{T, Mesh{T}, typeof(search), typeof(poll)}()
 
         p.N = N
         p.user_initial_point = convert(Vector{T},initial_point)

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -23,7 +23,7 @@ choices are (LTMADS)[@ref] and (NullSearch)[@ref] respectively.
 Note that if working with `Float64` (normally the case) then the type
 parameterisation can be ignored.
 """
-mutable struct DSProblem{T} <: AbstractProblem{T}
+mutable struct DSProblem{T, MT} <: AbstractProblem{T} where {MT <: AbstractMesh}
     #= Problem Definition =#
     objective::Function
     constraints::Constraints{T}
@@ -56,7 +56,7 @@ mutable struct DSProblem{T} <: AbstractProblem{T}
     status::Status
 
     #= Solver Config =#
-    config::Config{T}
+    config::Config{T, MT}
 
     DSProblem(N::Int;kwargs...) = DSProblem{Float64}(N; kwargs...)
 
@@ -70,7 +70,7 @@ mutable struct DSProblem{T} <: AbstractProblem{T}
                           kwargs...
                          ) where T
 
-        p = new()
+        p = new{T, Mesh{T}}()
 
         p.N = N
         p.user_initial_point = convert(Vector{T},initial_point)

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -23,7 +23,7 @@ choices are (LTMADS)[@ref] and (NullSearch)[@ref] respectively.
 Note that if working with `Float64` (normally the case) then the type
 parameterisation can be ignored.
 """
-mutable struct DSProblem{T, MT, ST, PT} <: AbstractProblem{T} where {MT <: AbstractMesh, ST <: AbstractSearch, PT <: AbstractPoll}
+mutable struct DSProblem{T, MT, ST, PT, CT} <: AbstractProblem{T} where {MT <: AbstractMesh, ST <: AbstractSearch, PT <: AbstractPoll, CT <: AbstractCache}
     #= Problem Definition =#
     objective::Function
     constraints::Constraints{T}
@@ -47,7 +47,7 @@ mutable struct DSProblem{T, MT, ST, PT} <: AbstractProblem{T} where {MT <: Abstr
     #Infeasible incumbent point evaluated cost
     i_cost::Union{T,Nothing}
 
-    cache::AbstractCache
+    cache::CT
 
     #TODO: proper stopping conditions
     iteration_limit::Int
@@ -70,7 +70,7 @@ mutable struct DSProblem{T, MT, ST, PT} <: AbstractProblem{T} where {MT <: Abstr
                           kwargs...
                          ) where T
 
-        p = new{T, Mesh{T}, typeof(search), typeof(poll)}()
+        p = new{T, Mesh{T}, typeof(search), typeof(poll), PointCache{T}}()
 
         p.N = N
         p.user_initial_point = convert(Vector{T},initial_point)
@@ -79,7 +79,7 @@ mutable struct DSProblem{T, MT, ST, PT} <: AbstractProblem{T} where {MT <: Abstr
 
         p.config = Config{T}(N, poll, search, Mesh{T}(N);kwargs...)
         p.status = Status()
-        p.cache=PointCache{T}()
+        p.cache = PointCache{T}()
         p.constraints = Constraints{T}()
 
         p.x = nothing

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -23,7 +23,7 @@ choices are (LTMADS)[@ref] and (NullSearch)[@ref] respectively.
 Note that if working with `Float64` (normally the case) then the type
 parameterisation can be ignored.
 """
-mutable struct DSProblem{T, MT} <: AbstractProblem{T} where {MT <: AbstractMesh}
+mutable struct DSProblem{T, MT, ST} <: AbstractProblem{T} where {MT <: AbstractMesh, ST <: AbstractSearch}
     #= Problem Definition =#
     objective::Function
     constraints::Constraints{T}
@@ -56,7 +56,7 @@ mutable struct DSProblem{T, MT} <: AbstractProblem{T} where {MT <: AbstractMesh}
     status::Status
 
     #= Solver Config =#
-    config::Config{T, MT}
+    config::Config{T, MT, ST}
 
     DSProblem(N::Int;kwargs...) = DSProblem{Float64}(N; kwargs...)
 
@@ -70,7 +70,7 @@ mutable struct DSProblem{T, MT} <: AbstractProblem{T} where {MT <: AbstractMesh}
                           kwargs...
                          ) where T
 
-        p = new{T, Mesh{T}}()
+        p = new{T, Mesh{T}, typeof(search)}()
 
         p.N = N
         p.user_initial_point = convert(Vector{T},initial_point)

--- a/src/DirectSearch.jl
+++ b/src/DirectSearch.jl
@@ -1,5 +1,6 @@
 module DirectSearch
 
+include("./Utils.jl")
 
 include("./Types.jl")
 include("./Cache.jl")

--- a/src/LTMADS.jl
+++ b/src/LTMADS.jl
@@ -16,7 +16,9 @@ mutable struct LTMADS{T} <: AbstractPoll
     b::Dict{T,Vector{T}}
     i::Dict{T,Int}
     maximal_basis::Bool
+
     LTMADS(;kwargs...) = LTMADS{Float64}(;kwargs...)
+
     function LTMADS{T}(;maximal_basis=true) where T
         g = new()
         g.b = Dict{T, Vector{T}}()

--- a/src/Mesh.jl
+++ b/src/Mesh.jl
@@ -7,6 +7,7 @@ Contains functions/type prototypes for the mesh.
 #Should make an effort to follow the naming conventions established
 #in existing methods in order to give compatibility between methods
 abstract type AbstractMesh end
+
 mutable struct Mesh{T} <: AbstractMesh
     G::Matrix{T}
     D::Matrix{T}

--- a/src/OrthoMADS.jl
+++ b/src/OrthoMADS.jl
@@ -93,7 +93,7 @@ function Halton(N::Int64, t::Int64)
 end
 
 function HaltonEntry(p,t)
-    u = 0
+    u = 0.0
     a_r = HaltonCoefficient(p,t)
     for (r,a) in enumerate(a_r)
         u += a/(p^r) #note that the equation is a/p^r+1, but julia indexes from 1
@@ -102,11 +102,11 @@ function HaltonEntry(p,t)
 end
 
 function HaltonCoefficient(p,t)
-    t==0 && return []
+    t==0 && return Int[]
     #Maximum non-zero value of r
     r_max = floor(Int64, log(p, t))
     #Need to give values for 0:r_max
-    a = zeros(Int(r_max+1))
+    a = zeros(Int, r_max+1)
     t_local = t
     for r in r_max:-1:0
         t_local == 0 && break
@@ -134,7 +134,7 @@ end
 
 #TODO use a better defined algorithm for this operation
 #(some kind of numerical line search?)
-function argmax(x, f, lim; iter_lim = 15)
+function argmax(x, f::Function, lim; iter_lim = 15)
     bump = 1
     iter = 1
 

--- a/src/Poll.jl
+++ b/src/Poll.jl
@@ -16,8 +16,7 @@ end
 Generate a set of directions with the configured polling algorithm, then return
 the set of points these directions give from the incumbent points.
 """
-function GeneratePollPoints(p::DSProblem{T}, ::AbstractMesh
-                           )::Vector{Vector{T}} where T
+function GeneratePollPoints(p::DSProblem{T}, ::AbstractMesh)::Vector{Vector{T}} where T
     points = []
     dirs = GenerateDirections(p)
 

--- a/src/Poll.jl
+++ b/src/Poll.jl
@@ -17,7 +17,7 @@ Generate a set of directions with the configured polling algorithm, then return
 the set of points these directions give from the incumbent points.
 """
 function GeneratePollPoints(p::DSProblem{T}, ::AbstractMesh)::Vector{Vector{T}} where T
-    points = []
+    points = Vector{T}[]
     dirs = GenerateDirections(p)
 
     if !isnothing(p.x)

--- a/src/Search.jl
+++ b/src/Search.jl
@@ -25,7 +25,7 @@ Search method that returns an empty vector.
 
 Use when no search method is desired.
 """
-GenerateSearchPoints(p::DSProblem, ::NullSearch) = []
+(GenerateSearchPoints(p::DSProblem{T}, ::NullSearch)::Vector{Vector{T}}) where T = []
 
 
 """

--- a/src/Search.jl
+++ b/src/Search.jl
@@ -25,7 +25,7 @@ Search method that returns an empty vector.
 
 Use when no search method is desired.
 """
-(GenerateSearchPoints(p::DSProblem{T}, ::NullSearch)::Vector{Vector{T}}) where T = []
+(GenerateSearchPoints(p::DSProblem{T}, ::NullSearch)::Vector{Vector{T}}) where T = Vector{T}[]
 
 
 """

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -50,10 +50,10 @@ be user-edited.
 Generally these are set at the start (automatically or via setter functions)
 and don't change.
 """
-mutable struct Config{FT<:AbstractFloat, MT<:AbstractMesh}
+mutable struct Config{FT<:AbstractFloat, MT<:AbstractMesh, ST<:AbstractSearch}
 
     poll::AbstractPoll
-    search::AbstractSearch
+    search::ST
 
     mesh::MT
     meshscale::Vector{FT}
@@ -69,7 +69,7 @@ mutable struct Config{FT<:AbstractFloat, MT<:AbstractMesh}
                         opportunistic::Bool=false,
                         kwargs...
                        ) where {FT<:AbstractFloat}
-        c = new{FT, typeof(mesh)}()
+        c = new{FT, typeof(mesh), typeof(search)}()
 
         c.poll = poll
         c.search = search

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -85,22 +85,22 @@ mutable struct Config{T}
     end
 end
 
-mutable struct Status{T}
-    function_evaluations::Int
-    iteration::Int
+mutable struct Status
+    function_evaluations::Int64
+    iteration::Int64
     optimization_status::OptimizationStatus
 
     #= Time Running Totals =#
-    runtime_total::T
-    search_time_total::T
-    poll_time_total::T
-    blackbox_time_total::T
+    runtime_total::Float64
+    search_time_total::Float64
+    poll_time_total::Float64
+    blackbox_time_total::Float64
 
     #= Start/End Time =#
-    start_time::T
-    end_time::T
+    start_time::Float64
+    end_time::Float64
 
-    function Status{T}() where T
+    function Status()
         s = new()
 
         s.function_evaluations = 0

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -50,12 +50,12 @@ be user-edited.
 Generally these are set at the start (automatically or via setter functions)
 and don't change.
 """
-mutable struct Config{FT<:AbstractFloat}
+mutable struct Config{FT<:AbstractFloat, MT<:AbstractMesh}
 
     poll::AbstractPoll
     search::AbstractSearch
 
-    mesh::AbstractMesh
+    mesh::MT
     meshscale::Vector{FT}
 
     num_procs::Int
@@ -65,11 +65,11 @@ mutable struct Config{FT<:AbstractFloat}
     function Config{FT}(N::Int,
                         poll::AbstractPoll,
                         search::AbstractSearch,
-                        mesh::AbstractMesh=Mesh{T}(N);
+                        mesh::AbstractMesh=Mesh{FT}(N);
                         opportunistic::Bool=false,
                         kwargs...
                        ) where {FT<:AbstractFloat}
-        c = new{FT}()
+        c = new{FT, typeof(mesh)}()
 
         c.poll = poll
         c.search = search

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -50,9 +50,9 @@ be user-edited.
 Generally these are set at the start (automatically or via setter functions)
 and don't change.
 """
-mutable struct Config{FT<:AbstractFloat, MT<:AbstractMesh, ST<:AbstractSearch}
+mutable struct Config{FT<:AbstractFloat, MT<:AbstractMesh, ST<:AbstractSearch, PT<:AbstractPoll}
 
-    poll::AbstractPoll
+    poll::PT
     search::ST
 
     mesh::MT
@@ -69,7 +69,7 @@ mutable struct Config{FT<:AbstractFloat, MT<:AbstractMesh, ST<:AbstractSearch}
                         opportunistic::Bool=false,
                         kwargs...
                        ) where {FT<:AbstractFloat}
-        c = new{FT, typeof(mesh), typeof(search)}()
+        c = new{FT, typeof(mesh), typeof(search), typeof(poll)}()
 
         c.poll = poll
         c.search = search

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -50,26 +50,26 @@ be user-edited.
 Generally these are set at the start (automatically or via setter functions)
 and don't change.
 """
-mutable struct Config{T}
+mutable struct Config{FT<:AbstractFloat}
 
     poll::AbstractPoll
     search::AbstractSearch
 
     mesh::AbstractMesh
-    meshscale::Vector{T}
+    meshscale::Vector{FT}
 
     num_procs::Int
     max_simultanious_evaluations::Int
     opportunistic::Bool
 
-    function Config{T}(N::Int,
-                       poll::AbstractPoll,
-                       search::AbstractSearch,
-                       mesh::AbstractMesh=Mesh{T}(N);
-                       opportunistic::Bool=false,
-                       kwargs...
-                      ) where T
-        c = new()
+    function Config{FT}(N::Int,
+                        poll::AbstractPoll,
+                        search::AbstractSearch,
+                        mesh::AbstractMesh=Mesh{T}(N);
+                        opportunistic::Bool=false,
+                        kwargs...
+                       ) where {FT<:AbstractFloat}
+        c = new{FT}()
 
         c.poll = poll
         c.search = search

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,0 +1,4 @@
+# Create an inf value in a given float type
+inf(::Type{Float64}) = Inf64
+inf(::Type{Float32}) = Inf32
+inf(::Type{Float16}) = Inf16


### PR DESCRIPTION
I have been going through the code using `@code_warntype` and we have had numerous places in the package where the compiler was unable to perform type inference at compile time leading to inefficient dispatching at runtime. This PR contains the high level changes to the main parts of the code, but there are still some type stability problems lurking in the depths of the code (such as the OrthoMADS computations). The main thing I have done is convert the abstract types inside of the structures to be concrete types and make the main problem then be parametric on them. There were also some problems using non-Float64 numbers (such as Float32), so I cleaned up the typing inside the constraints where that seemed to be the largest problem.

I benchmarked this on the rosenbrock function and here are the times I saw:

Before:
```julia
julia> @benchmark Optimize!(p) setup=(p = DSProblem(3); SetObjective( p, DS.rosenbrock ))
BenchmarkTools.Trial:
  memory estimate:  9.08 MiB
  allocs estimate:  167154
  --------------
  minimum time:     16.152 ms (0.00% GC)
  median time:      16.368 ms (0.00% GC)
  mean time:        17.082 ms (2.46% GC)
  maximum time:     27.947 ms (22.48% GC)
  --------------
  samples:          293
  evals/sample:     1
```

After:
```julia
julia> @benchmark Optimize!(p) setup=(p = DSProblem(3); SetObjective( p, DS.rosenbrock ))
BenchmarkTools.Trial:
  memory estimate:  7.08 MiB
  allocs estimate:  88178
  --------------
  minimum time:     11.699 ms (0.00% GC)
  median time:      11.802 ms (0.00% GC)
  mean time:        12.262 ms (2.65% GC)
  maximum time:     18.065 ms (22.72% GC)
  --------------
  samples:          408
  evals/sample:     1
```