### PR TITLE
Reduce polling at the non-important iterate

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -39,8 +39,12 @@ mutable struct DSProblem{T, UT, MT, ST, PT, CT} <: AbstractProblem{T} where {MT 
     granularity::Vector{T}
     lower_bounds::Vector{Union{T, Nothing}}
     upper_bounds::Vector{Union{T, Nothing}}
-    #Barrier threshold
-    h_max::T
+
+    # Parameters associated with the progressive barrier
+    h_max::T                  # Barrier threshold
+    frame_center_trigger::T   # The tolerance to use when choosing the primary poll center
+    num_secondary_points::Int # The number of points to search around the secondary poll center
+
     sense::ProblemSense
 
     #TODO incumbent points should be sets not points, therefore change to vectors of points
@@ -114,6 +118,9 @@ mutable struct DSProblem{T, UT, MT, ST, PT, CT} <: AbstractProblem{T} where {MT 
         p.x_cost = nothing
         p.i = nothing
         p.i_cost = nothing
+
+        p.frame_center_trigger = 10
+        p.num_secondary_points = min(N, 2)
 
         if objective != nothing
             p.objective = objective

--- a/src/polling/poll.jl
+++ b/src/polling/poll.jl
@@ -20,18 +20,45 @@ function GeneratePollPoints(p::DSProblem{T}, ::AbstractMesh)::Vector{Vector{T}} 
 
     directions = []
 
-    if !isnothing(p.x)
-        for i=1:size(dirs,2)
-            d = dirs[:,i]
-            push!(points, PollPointGeneration(p.x, d, p.config.mesh))
-            push!(directions, d)
+    secondarycenter = nothing
+
+    # Determine the primary polling center
+    if isnothing(p.x)
+        # Use the infeasible point as the center
+        primarycenter = p.i
+    elseif isnothing(p.i)
+        # Use the feasible point as the center
+        primarycenter = p.x
+    else
+        # Compare the current cost of each to determine the primary poll center
+        if p.x_cost - p.frame_center_trigger > p.i_cost
+            primarycenter   = p.i
+            secondarycenter = p.x
+        else
+            primarycenter   = p.x
+            secondarycenter = p.i
         end
+
     end
-    if !isnothing(p.i)
-        for i=1:size(dirs,2)
+
+    # Generate the directions around the primary poll center
+    for i=1:size(dirs,2)
+        d = dirs[:,i]
+        push!(points, PollPointGeneration(primarycenter, d, p.config.mesh))
+        push!(directions, d)
+    end
+
+    # Generate the points around the secondary center
+    ndirs = Int( ceil( p.num_secondary_points / 2 ) )
+
+    if !isnothing( secondarycenter )
+        for i=1:min(ndirs, size(dirs,2) )
             d = dirs[:,i]
-            push!(points, PollPointGeneration(p.i, d, p.config.mesh))
+            push!(points, PollPointGeneration(secondarycenter, d, p.config.mesh))
             push!(directions, d)
+
+            push!(points, PollPointGeneration(secondarycenter, -d, p.config.mesh))
+            push!(directions, -d)
         end
     end
 


### PR DESCRIPTION
This is suggested in the original progressive barrier paper as a way to reduce the computational burden of the progressive barrier implementation and not just double the workload.

It is added as a parameter though, so if desired it could be set anywhere between 1 and n, but defaults to 2.