### PR TITLE
Add Aqua tests in the testsuite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,11 @@ SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 Unmarshal = "cbff2730-442d-58d7-89d1-8e530c41eb02"
 
 [compat]
-julia = "1.3.1"
+JLD2 = "0.4"
+JSON = "0.21"
+Primes = "0.5"
+Unmarshal = "0.4"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,9 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Aqua = "0.5"

--- a/test/aqua_test.jl
+++ b/test/aqua_test.jl
@@ -1,0 +1,4 @@
+using DirectSearch
+using Aqua
+
+Aqua.test_all(DirectSearch)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,3 +22,6 @@ end
 @testset "Mesh" begin
     @safetestset "Anisotropic Mesh" begin include( "./mesh/test_anisotropic.jl" ) end
 end
+
+# Run the Aqua tests to check other parts of the package
+@safetestset "Aqua" begin include("./aqua_test.jl") end


### PR DESCRIPTION
[Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) is a package that can automatically test code to identify possible issues (like unused type parameters, undefined exports, compat entries, etc.) This adds it into the main test suite to check for issues.

Also add compat bounds for the dependent packages to make all Aqua tests pass.