### PR TITLE
Always run CI on latest stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
The action expects semver, so saying a version of '1' will automatically get the latest version of the Julia releases.